### PR TITLE
Added GmailMessageList for chained filtering

### DIFF
--- a/src/main/java/com/googlecode/gmail4j/GmailClient.java
+++ b/src/main/java/com/googlecode/gmail4j/GmailClient.java
@@ -88,7 +88,7 @@ public abstract class GmailClient {
      * @param strategy search strategy
      * @param value the value to look for
      */
-    public abstract List<GmailMessage> getMessagesBy(EmailSearchStrategy strategy, String value);
+    public abstract GmailMessageList getMessagesBy(EmailSearchStrategy strategy, String value);
     
     /**
      * Sends the message

--- a/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
+++ b/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
@@ -1,0 +1,243 @@
+package com.googlecode.gmail4j;
+
+import com.googlecode.gmail4j.javamail.JavaMailGmailMessage;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.mail.Flags;
+import javax.mail.search.BodyTerm;
+import javax.mail.search.FlagTerm;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.ListIterator;
+
+
+public class GmailMessageList implements List{
+
+    /**
+     * Logger
+     */
+    private static final Log LOG = LogFactory.getLog(GmailMessageList.class);
+
+    private List<GmailMessage> emails;
+
+    public GmailMessageList()
+    {
+        emails = new LinkedList<GmailMessage>();
+    }
+
+    public GmailMessageList(List<GmailMessage> emails)
+    {
+        this.emails = emails;
+    }
+
+    /**
+     * Returns list of matching {@link GmailMessage} objects
+     *
+     * @param strategy search strategy
+     * @param value the value to look for
+     */
+    public GmailMessageList filterMessagesBy(GmailClient.EmailSearchStrategy strategy, String value)    throws Exception
+    {
+        LOG.debug("Retrieving emails where " + strategy.name() + " equals " + value);
+        List<GmailMessage> matchedEmails = new LinkedList<GmailMessage>();
+        Date dateToLookFor = null;
+        if (strategy == GmailClient.EmailSearchStrategy.DATE_EQ
+                || strategy == GmailClient.EmailSearchStrategy.DATE_GT
+                || strategy == GmailClient.EmailSearchStrategy.DATE_LT)
+        {
+            dateToLookFor = new Date(Date.parse(value));
+        }
+        int total = emails.size();
+        int counter = 0;
+        boolean wasFound;
+        for (GmailMessage message : emails)
+        {
+            switch (strategy)
+            {
+                case SUBJECT:
+                    if (message.getSubject().equals(value))
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case DATE_EQ:
+                    if (message.getSendDate().compareTo(dateToLookFor)== 0)
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case DATE_GT:
+                    if (message.getSendDate().compareTo(dateToLookFor) > 0)
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case DATE_LT:
+                    if (message.getSendDate().compareTo(dateToLookFor) < 0)
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case TO:
+                    wasFound = false;
+                    List<EmailAddress> emailAddressesTo = message.getTo();
+                    for (EmailAddress address : emailAddressesTo)
+                    {
+                        if (address.getEmail().equalsIgnoreCase(value))
+                        {
+                            wasFound = true;
+                        }
+                    }
+                    if (wasFound)
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case FROM:
+                    if (message.getFrom().getEmail().equalsIgnoreCase(value))
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case KEYWORD:
+                    if (((JavaMailGmailMessage)message).getMessage().match(new BodyTerm(value)))
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case CC:
+                    wasFound = false;
+                    List<EmailAddress> emailAddressesCC = message.getCc();
+                    for (EmailAddress address : emailAddressesCC)
+                    {
+                        if (address.getEmail().equalsIgnoreCase(value))
+                        {
+                            wasFound = true;
+                        }
+                    }
+                    if (wasFound)
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+                case UNREAD:
+                    if (((JavaMailGmailMessage)message).getMessage()
+                            .match(new FlagTerm(new Flags(Flags.Flag.SEEN), false)))
+                    {
+                        matchedEmails.add(message);
+                    }
+                    break;
+            }
+            LOG.debug("Processing record: " + counter + " of " + total + "  "
+                    + Math.round( ((double)counter * 100) / ((double)total) ) + "% done");
+            counter++;
+        }
+        if (matchedEmails.size() == 0)
+        {
+            LOG.debug("No emails found with " + strategy.name() + " of " + value);
+        }
+        else
+        {
+            LOG.debug("Filtered down to " + matchedEmails.size() + " from " + this.emails.size()
+                    + " on criteria " + strategy.name() + " equal to " + value);
+        }
+        return new GmailMessageList(matchedEmails);
+    }
+
+    public int size() {
+        return emails.size();
+    }
+
+    public boolean isEmpty() {
+        return emails.isEmpty();
+    }
+
+    public boolean contains(Object o) {
+        return emails.contains(o);
+    }
+
+    public Iterator iterator() {
+        return emails.iterator();
+    }
+
+    public Object[] toArray() {
+        return emails.toArray();
+    }
+
+    public boolean add(Object o) {
+        return emails.add((GmailMessage)o);
+    }
+
+    public boolean remove(Object o) {
+        return emails.remove((GmailMessage)o);
+    }
+
+    public boolean containsAll(Collection<?> c) {
+        return emails.containsAll((Collection <GmailMessage>)c);
+    }
+
+    public boolean addAll(Collection c) {
+        return emails.addAll((Collection<GmailMessage>) c);
+    }
+
+    public boolean addAll(int index, Collection c) {
+        return emails.addAll(index, (Collection<GmailMessage>) c);
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        return emails.removeAll((Collection<GmailMessage>) c);
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        return emails.retainAll((Collection<GmailMessage>) c);
+    }
+
+    public void clear() {
+        emails.clear();
+    }
+
+    public Object get(int index) {
+        return emails.get(index);
+    }
+
+    public Object set(int index, Object element) {
+        return emails.set(index,(GmailMessage)element);
+    }
+
+    public void add(int index, Object element) {
+        emails.add(index,(GmailMessage)element);
+    }
+
+    public Object remove(int index) {
+        return emails.remove(index);
+    }
+
+    public int indexOf(Object o) {
+        return emails.indexOf((GmailMessage)o);
+    }
+
+    public int lastIndexOf(Object o) {
+        return emails.lastIndexOf((GmailMessage)o);
+    }
+
+    public ListIterator listIterator() {
+        return emails.listIterator();
+    }
+
+    public ListIterator listIterator(int index) {
+        return emails.listIterator(index);
+    }
+
+    public List subList(int fromIndex, int toIndex) {
+        return emails.subList(fromIndex,toIndex);
+    }
+
+    public Object[] toArray(Object[] a) {
+        return emails.toArray((GmailMessage[])a);
+    }
+}

--- a/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
+++ b/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.ListIterator;
 
 
-public class GmailMessageList implements List<GmailMessage>{
+public class GmailMessageList implements List<GmailMessage> {
 
     /**
      * Logger
@@ -25,13 +25,11 @@ public class GmailMessageList implements List<GmailMessage>{
 
     private List<GmailMessage> emails;
 
-    public GmailMessageList()
-    {
+    public GmailMessageList() {
         emails = new LinkedList<GmailMessage>();
     }
 
-    public GmailMessageList(List<GmailMessage> emails)
-    {
+    public GmailMessageList(List<GmailMessage> emails) {
         this.emails = emails;
     }
 
@@ -41,94 +39,78 @@ public class GmailMessageList implements List<GmailMessage>{
      * @param strategy search strategy
      * @param value the value to look for
      */
-    public GmailMessageList filterMessagesBy(GmailClient.EmailSearchStrategy strategy, String value)    throws Exception
-    {
+    public GmailMessageList filterMessagesBy(GmailClient.EmailSearchStrategy strategy, String value)
+            throws Exception {
         LOG.debug("Retrieving emails where " + strategy.name() + " equals " + value);
         List<GmailMessage> matchedEmails = new LinkedList<GmailMessage>();
         Date dateToLookFor = null;
         if (strategy == GmailClient.EmailSearchStrategy.DATE_EQ
                 || strategy == GmailClient.EmailSearchStrategy.DATE_GT
-                || strategy == GmailClient.EmailSearchStrategy.DATE_LT)
-        {
+                || strategy == GmailClient.EmailSearchStrategy.DATE_LT) {
             dateToLookFor = new Date(Date.parse(value));
         }
         int total = emails.size();
         int counter = 0;
         boolean wasFound;
-        for (GmailMessage message : emails)
-        {
-            switch (strategy)
-            {
+        for (GmailMessage message : emails) {
+            switch (strategy) {
                 case SUBJECT:
-                    if (message.getSubject().equals(value))
-                    {
+                    if (message.getSubject().equals(value)) {
                         matchedEmails.add(message);
                     }
                     break;
                 case DATE_EQ:
-                    if (message.getSendDate().compareTo(dateToLookFor)== 0)
-                    {
+                    if (message.getSendDate().compareTo(dateToLookFor) == 0) {
                         matchedEmails.add(message);
                     }
                     break;
                 case DATE_GT:
-                    if (message.getSendDate().compareTo(dateToLookFor) > 0)
-                    {
+                    if (message.getSendDate().compareTo(dateToLookFor) > 0) {
                         matchedEmails.add(message);
                     }
                     break;
                 case DATE_LT:
-                    if (message.getSendDate().compareTo(dateToLookFor) < 0)
-                    {
+                    if (message.getSendDate().compareTo(dateToLookFor) < 0) {
                         matchedEmails.add(message);
                     }
                     break;
                 case TO:
                     wasFound = false;
                     List<EmailAddress> emailAddressesTo = message.getTo();
-                    for (EmailAddress address : emailAddressesTo)
-                    {
-                        if (address.getEmail().equalsIgnoreCase(value))
-                        {
+                    for (EmailAddress address : emailAddressesTo) {
+                        if (address.getEmail().equalsIgnoreCase(value)) {
                             wasFound = true;
                         }
                     }
-                    if (wasFound)
-                    {
+                    if (wasFound) {
                         matchedEmails.add(message);
                     }
                     break;
                 case FROM:
-                    if (message.getFrom().getEmail().equalsIgnoreCase(value))
-                    {
+                    if (message.getFrom().getEmail().equalsIgnoreCase(value)) {
                         matchedEmails.add(message);
                     }
                     break;
                 case KEYWORD:
-                    if (((JavaMailGmailMessage)message).getMessage().match(new BodyTerm(value)))
-                    {
+                    if (((JavaMailGmailMessage)message).getMessage().match(new BodyTerm(value))) {
                         matchedEmails.add(message);
                     }
                     break;
                 case CC:
                     wasFound = false;
                     List<EmailAddress> emailAddressesCC = message.getCc();
-                    for (EmailAddress address : emailAddressesCC)
-                    {
-                        if (address.getEmail().equalsIgnoreCase(value))
-                        {
+                    for (EmailAddress address : emailAddressesCC) {
+                        if (address.getEmail().equalsIgnoreCase(value)) {
                             wasFound = true;
                         }
                     }
-                    if (wasFound)
-                    {
+                    if (wasFound) {
                         matchedEmails.add(message);
                     }
                     break;
                 case UNREAD:
                     if (((JavaMailGmailMessage)message).getMessage()
-                            .match(new FlagTerm(new Flags(Flags.Flag.SEEN), false)))
-                    {
+                            .match(new FlagTerm(new Flags(Flags.Flag.SEEN), false))) {
                         matchedEmails.add(message);
                     }
                     break;
@@ -137,12 +119,10 @@ public class GmailMessageList implements List<GmailMessage>{
                     + Math.round( ((double)counter * 100) / ((double)total) ) + "% done");
             counter++;
         }
-        if (matchedEmails.size() == 0)
-        {
+        if (matchedEmails.size() == 0) {
             LOG.debug("No emails found with " + strategy.name() + " of " + value);
         }
-        else
-        {
+        else {
             LOG.debug("Filtered down to " + matchedEmails.size() + " from " + this.emails.size()
                     + " on criteria " + strategy.name() + " equal to " + value);
         }

--- a/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
+++ b/src/main/java/com/googlecode/gmail4j/GmailMessageList.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.ListIterator;
 
 
-public class GmailMessageList implements List{
+public class GmailMessageList implements List<GmailMessage>{
 
     /**
      * Logger
@@ -169,16 +169,16 @@ public class GmailMessageList implements List{
         return emails.toArray();
     }
 
-    public boolean add(Object o) {
+    public boolean add(GmailMessage o) {
         return emails.add((GmailMessage)o);
     }
 
     public boolean remove(Object o) {
-        return emails.remove((GmailMessage)o);
+        return emails.remove(o);
     }
 
     public boolean containsAll(Collection<?> c) {
-        return emails.containsAll((Collection <GmailMessage>)c);
+        return emails.containsAll(c);
     }
 
     public boolean addAll(Collection c) {
@@ -190,39 +190,39 @@ public class GmailMessageList implements List{
     }
 
     public boolean removeAll(Collection<?> c) {
-        return emails.removeAll((Collection<GmailMessage>) c);
+        return emails.removeAll(c);
     }
 
     public boolean retainAll(Collection<?> c) {
-        return emails.retainAll((Collection<GmailMessage>) c);
+        return emails.retainAll(c);
     }
 
     public void clear() {
         emails.clear();
     }
 
-    public Object get(int index) {
+    public GmailMessage get(int index) {
         return emails.get(index);
     }
 
-    public Object set(int index, Object element) {
+    public GmailMessage set(int index, GmailMessage element) {
         return emails.set(index,(GmailMessage)element);
     }
 
-    public void add(int index, Object element) {
+    public void add(int index, GmailMessage element) {
         emails.add(index,(GmailMessage)element);
     }
 
-    public Object remove(int index) {
+    public GmailMessage remove(int index) {
         return emails.remove(index);
     }
 
     public int indexOf(Object o) {
-        return emails.indexOf((GmailMessage)o);
+        return emails.indexOf(o);
     }
 
     public int lastIndexOf(Object o) {
-        return emails.lastIndexOf((GmailMessage)o);
+        return emails.lastIndexOf(o);
     }
 
     public ListIterator listIterator() {

--- a/src/main/java/com/googlecode/gmail4j/javamail/ImapGmailClient.java
+++ b/src/main/java/com/googlecode/gmail4j/javamail/ImapGmailClient.java
@@ -37,6 +37,7 @@ import com.googlecode.gmail4j.GmailClient;
 import com.googlecode.gmail4j.GmailException;
 import com.googlecode.gmail4j.GmailMessage;
 
+import com.googlecode.gmail4j.GmailMessageList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -181,7 +182,7 @@ public class ImapGmailClient extends GmailClient {
     }
 
     @Override
-    public List<GmailMessage> getMessagesBy(EmailSearchStrategy strategy, String value)
+    public GmailMessageList getMessagesBy(EmailSearchStrategy strategy, String value)
     {
         SearchTerm seekStrategy = null;
         switch(strategy)
@@ -230,7 +231,7 @@ public class ImapGmailClient extends GmailClient {
                 break;
         }
         try {
-            final List<GmailMessage> found = new ArrayList<GmailMessage>();
+            final GmailMessageList found = new GmailMessageList();
             final Store store = openGmailStore();
             final Folder folder = getFolder(this.srcFolder,store);
             folder.open(Folder.READ_ONLY);

--- a/src/test/java/com/googlecode/gmail4j/test/imap/ImapGmailClientTest.java
+++ b/src/test/java/com/googlecode/gmail4j/test/imap/ImapGmailClientTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -153,11 +154,16 @@ public class ImapGmailClientTest {
                 connection.setProxy(conf.getProxyHost(), conf.getProxyPort());
                 connection.setProxyCredentials(conf.getProxyCredentials());
             }
-            log.debug("Getting unread messages");
+            Date date = new Date();
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            cal.add(Calendar.DATE, -1);
+            date = cal.getTime();
+            log.debug("Getting messages newer than yesterday" + date.toString());
             client.setConnection(connection);
             final List<GmailMessage> messages = client.getMessagesBy(
                     GmailClient.EmailSearchStrategy.DATE_GT,
-                    new Date().toString());
+                    date.toString());
             for (GmailMessage message : messages) {
                 log.debug(message);
             }
@@ -184,7 +190,7 @@ public class ImapGmailClientTest {
                 connection.setProxy(conf.getProxyHost(), conf.getProxyPort());
                 connection.setProxyCredentials(conf.getProxyCredentials());
             }
-            log.debug("Getting unread messages");
+            log.debug("Getting messages by subject");
             client.setConnection(connection);
             final List<GmailMessage> messages = client.getMessagesBy(
                     GmailClient.EmailSearchStrategy.SUBJECT,
@@ -215,10 +221,42 @@ public class ImapGmailClientTest {
                 connection.setProxy(conf.getProxyHost(), conf.getProxyPort());
                 connection.setProxyCredentials(conf.getProxyCredentials());
             }
-            log.debug("Getting unread messages");
+            log.debug("Getting messages by keyword");
             client.setConnection(connection);
             final List<GmailMessage> messages = client.getMessagesBy(
                     GmailClient.EmailSearchStrategy.KEYWORD,"Unicode");
+            for (GmailMessage message : messages) {
+                log.debug(message);
+            }
+            assertNotNull("Messages are not null", messages);
+        } catch (final Exception e) {
+            log.error("Test Failed", e);
+            fail("Caught exception: " + e.getMessage());
+        } finally {
+            client.disconnect();
+        }
+    }
+
+    /**
+     * Tests retrieval of messages by keyword as well as chained filtering
+     * with the GmailMessageList class
+     */
+    @Test
+    public void testGetMessagesByMultipleKeywords() {
+        final ImapGmailClient client = new ImapGmailClient(ImapGmailLabel.SENT_MAIL);
+        final ImapGmailConnection connection = new ImapGmailConnection();
+
+        try {
+            connection.setLoginCredentials(conf.getGmailCredentials());
+            if (conf.useProxy()) {
+                connection.setProxy(conf.getProxyHost(), conf.getProxyPort());
+                connection.setProxyCredentials(conf.getProxyCredentials());
+            }
+            log.debug("Getting unread messages");
+            client.setConnection(connection);
+            final List<GmailMessage> messages = client.getMessagesBy(
+                    GmailClient.EmailSearchStrategy.KEYWORD,"Unicode")
+                    .filterMessagesBy(GmailClient.EmailSearchStrategy.KEYWORD,"ąžuolėlį");
             for (GmailMessage message : messages) {
                 log.debug(message);
             }


### PR DESCRIPTION
The new class wraps the List<GmailMessage> that is normally returned so that search criteria can be chained together with a clean syntax:

getMessagesBy(EmailSearchStrategy.KEYWORD,"foo")
   .filterMessagesBy(EmailSearchStrategy.KEYWORD,"bar")
   .filterMessagesBy(EmailSearchStrategy.SUBJECT,"foobar")
